### PR TITLE
fix: in some cases usernames are not correctly parsed

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -10,8 +10,8 @@ custom:
     dev: '23178'
     prod: '23186'
   botName:
-    dev: '@AllContributorsDev'
-    prod: '@AllContributorsBot'
+    dev: 'AllContributorsDev'
+    prod: 'AllContributorsBot'
   logLevel:
     dev: debug
     prod: debug # TODO change to info soon

--- a/src/processIssueComment.js
+++ b/src/processIssueComment.js
@@ -6,6 +6,7 @@ const ContentFiles = require('./ContentFiles')
 const getUserDetails = require('./utils/getUserDetails')
 const parseComment = require('./utils/parse-comment')
 
+const isMessageForBot = require('./utils/isMessageForBot')
 const { GIHUB_BOT_NAME } = require('./utils/settings')
 const { AllContributorBotError } = require('./utils/errors')
 
@@ -69,13 +70,6 @@ async function processIssueComment({ context, commentReply }) {
 
     const commentBody = context.payload.comment.body
     const parsedComment = parseComment(commentBody)
-    if (!parsedComment.action) {
-        commentReply.reply(`I could not determine your intention.`)
-        commentReply.reply(
-            `Basic usage: @${GIHUB_BOT_NAME} please add jakebolam for code, doc`,
-        )
-        return
-    }
 
     if (parsedComment.action === 'add') {
         await processAddContributor({
@@ -89,17 +83,14 @@ async function processIssueComment({ context, commentReply }) {
         return
     }
 
-    commentReply.reply(`I'm not sure how to ${parsedComment.action}`)
+    commentReply.reply(`I could not determine your intention.`)
     commentReply.reply(
-        `Basic usage: @${GIHUB_BOT_NAME} please add jakebolam for code, doc`,
+        `Basic usage: @${GIHUB_BOT_NAME} please add jakebolam for code, doc and infra`,
+    )
+    commentReply(
+        `For other usage see the [documentation](https://github.com/all-contributors/all-contributors-bot#usage)`,
     )
     return
-}
-
-function hasMentionedBotName(context) {
-    const commentBody = context.payload.comment.body
-    const hasMentionedBotName = commentBody.includes(GIHUB_BOT_NAME)
-    return hasMentionedBotName
 }
 
 async function processIssueCommentSafe({ context }) {
@@ -108,7 +99,8 @@ async function processIssueCommentSafe({ context }) {
         return
     }
 
-    if (!hasMentionedBotName(context)) {
+    const commentBody = context.payload.comment.body
+    if (!isMessageForBot(commentBody)) {
         context.log.debug('Message not for us, exiting')
         return
     }

--- a/src/utils/isMessageForBot.js
+++ b/src/utils/isMessageForBot.js
@@ -1,0 +1,8 @@
+const { GIHUB_BOT_NAME } = require('./settings')
+
+function isMessageForBot(message) {
+    const isMessageForBot = message.includes(`@${GIHUB_BOT_NAME}`)
+    return isMessageForBot
+}
+
+module.exports = isMessageForBot

--- a/test/setup.js
+++ b/test/setup.js
@@ -2,4 +2,4 @@ const nock = require('nock')
 
 nock.disableNetConnect()
 
-process.env.BOT_NAME = '@AllContributorsBotTest'
+process.env.BOT_NAME = 'AllContributorsBotTest'

--- a/test/utils/isMessageForBot.test.js
+++ b/test/utils/isMessageForBot.test.js
@@ -1,0 +1,31 @@
+const isMessageForBot = require('../../src/utils/isMessageForBot')
+
+describe('isMessageForBot', () => {
+    const testBotName = 'AllContributorsBotTest'
+
+    test('For us', () => {
+        expect(
+            isMessageForBot(
+                `@${testBotName} please add jakebolam for doc, infra and code`,
+            ),
+        ).toBe(true)
+
+        expect(
+            isMessageForBot(
+                `@AllContributorsBotTest please add jakebolam for doc, infra and code`,
+            ),
+        ).toBe(true)
+    })
+
+    test('Not for us', () => {
+        expect(
+            isMessageForBot(
+                `${testBotName} please add jakebolam for doc, infra and code`,
+            ),
+        ).toBe(false)
+
+        expect(
+            isMessageForBot(`Please add jakebolam for doc, infra and code`),
+        ).toBe(false)
+    })
+})

--- a/test/utils/parse-comment/index.test.js
+++ b/test/utils/parse-comment/index.test.js
@@ -13,6 +13,28 @@ describe('parseComment', () => {
             contributions: ['doc', 'infra', 'code'],
         })
     })
+
+    test('Basic intent to add - non name username', () => {
+        expect(
+            parseComment(
+                `@${GIHUB_BOT_NAME} please add tbenning for design`,
+            ),
+        ).toEqual({
+            action: 'add',
+            who: 'tbenning',
+            contributions: ['design'],
+        })
+
+        expect(
+            parseComment(
+                `@${GIHUB_BOT_NAME} please add Rbot25_RULES for design`,
+            ),
+        ).toEqual({
+            action: 'add',
+            who: 'Rbot25_RULES',
+            contributions: ['tools'],
+        })
+    })
     //
     // test('Basic intent to add (with plurals)', () => {
     //     expect(

--- a/test/utils/parse-comment/index.test.js
+++ b/test/utils/parse-comment/index.test.js
@@ -1,11 +1,12 @@
 const parseComment = require('../../../src/utils/parse-comment')
-const { GIHUB_BOT_NAME } = require('../../../src//utils/settings')
 
 describe('parseComment', () => {
+    const testBotName = 'AllContributorsBotTest'
+
     test('Basic intent to add', () => {
         expect(
             parseComment(
-                `@${GIHUB_BOT_NAME} please add jakebolam for doc, infra and code`,
+                `@${testBotName} please add jakebolam for doc, infra and code`,
             ),
         ).toEqual({
             action: 'add',
@@ -16,35 +17,39 @@ describe('parseComment', () => {
 
     test('Basic intent to add - non name username', () => {
         expect(
-            parseComment(
-                `@${GIHUB_BOT_NAME} please add tbenning for design`,
-            ),
+            parseComment(`@${testBotName} please add tbenning for design`),
         ).toEqual({
             action: 'add',
             who: 'tbenning',
             contributions: ['design'],
         })
+    })
 
+    test('Basic intent to add - captialized username', () => {
         expect(
-            parseComment(
-                `@${GIHUB_BOT_NAME} please add Rbot25_RULES for design`,
-            ),
+            parseComment(`@${testBotName} please add Rbot25_RULES for tool`),
         ).toEqual({
             action: 'add',
             who: 'Rbot25_RULES',
-            contributions: ['tools'],
+            contributions: ['tool'],
+        })
+    })
+
+    test('Intent unknown', () => {
+        expect(
+            parseComment(`@${testBotName} please lollmate for tool`),
+        ).toEqual({
+            action: false,
         })
     })
     //
     // test('Basic intent to add (with plurals)', () => {
     //     expect(
-    //         parseComment(
-    //             `@${GIHUB_BOT_NAME} please add jakebolam for docs, infra and code`,
-    //         ),
+    //         parseComment(`@${testBotName} please add dat2 for docs`),
     //     ).toEqual({
     //         action: 'add',
-    //         who: 'jakebolam',
-    //         contributions: ['doc', 'infra', 'code'],
+    //         who: 'dat2',
+    //         contributions: ['doc'],
     //     })
     // })
 })


### PR DESCRIPTION
Fixes cases where usernames not correctly parsed.

Also addressed issue where bot name was @@botname in some cases

<img width="808" alt="screen shot 2019-01-13 at 9 44 44 pm" src="https://user-images.githubusercontent.com/3534236/51086040-781c1280-177c-11e9-93d7-c4143d38cb4a.png">
