### PR TITLE
fix: commentReply is not a function

### DIFF
--- a/src/processIssueComment.js
+++ b/src/processIssueComment.js
@@ -86,7 +86,7 @@ async function processIssueComment({ context, commentReply }) {
     commentReply.reply(
         `Basic usage: @${GIHUB_BOT_NAME} please add jakebolam for code, doc and infra`,
     )
-    commentReply(
+    commentReply.reply(
         `For other usage see the [documentation](https://github.com/all-contributors/all-contributors-bot#usage)`,
     )
     return


### PR DESCRIPTION
This showed up in sentry: https://sentry.io/all-contributors/github-bot/issues/845638720/events/42773873695/