### PR TITLE
fix: avoid PRs when there's no contributions

### DIFF
--- a/src/tasks/processIssueComment/probot-processIssueComment.js
+++ b/src/tasks/processIssueComment/probot-processIssueComment.js
@@ -22,6 +22,12 @@ async function processAddContributor({
     contributions,
     defaultBranch,
 }) {
+    if (!contributions.length) {
+        return commentReply.reply(
+            `I couldn't determine any contributions to add, did you specify any contributions?`,
+        )
+    }
+
     const { name, avatar_url, profile } = await getUserDetails({
         github: context.github,
         username: who,
@@ -49,24 +55,18 @@ async function processAddContributor({
         originalSha: optionsConfig.getOriginalSha(),
     }
 
-    if (contributions.length) {
-        const pullRequestURL = await repository.createPullRequestFromFiles({
-            title: `docs: add ${who} as a contributor`,
-            body: `Adds @${who} as a contributor for ${contributions.join(
-                ', ',
-            )}.\n\nThis was requested by ${commentReply.replyingToWho()} [in this comment](${commentReply.replyingToWhere()})`,
-            filesByPath: filesByPathToUpdate,
-            branchName: `all-contributors/add-${who}`,
-        })
+    const pullRequestURL = await repository.createPullRequestFromFiles({
+        title: `docs: add ${who} as a contributor`,
+        body: `Adds @${who} as a contributor for ${contributions.join(
+            ', ',
+        )}.\n\nThis was requested by ${commentReply.replyingToWho()} [in this comment](${commentReply.replyingToWhere()})`,
+        filesByPath: filesByPathToUpdate,
+        branchName: `all-contributors/add-${who}`,
+    })
 
-        commentReply.reply(
-            `I've put up [a pull request](${pullRequestURL}) to add @${who}! :tada:`,
-        )
-    } else {
-        commentReply.reply(
-            `I could not find any contributions associated to @${who}! :sod:`,
-        )
-    }
+    commentReply.reply(
+        `I've put up [a pull request](${pullRequestURL}) to add @${who}! :tada:`,
+    )
 }
 
 async function probotProcessIssueComment({ context, commentReply }) {

--- a/src/tasks/processIssueComment/probot-processIssueComment.js
+++ b/src/tasks/processIssueComment/probot-processIssueComment.js
@@ -23,8 +23,10 @@ async function processAddContributor({
     defaultBranch,
 }) {
     if (!contributions.length) {
+        context.log.debug('No contributions')
         return commentReply.reply(
-            `I couldn't determine any contributions to add, did you specify any contributions?`,
+            `I couldn't determine any contributions to add, did you specify any contributions?
+            Please make sure to use [valid contribution names](https://github.com/all-contributors/all-contributors#emoji-key-).`,
         )
     }
 

--- a/src/tasks/processIssueComment/probot-processIssueComment.js
+++ b/src/tasks/processIssueComment/probot-processIssueComment.js
@@ -57,18 +57,26 @@ async function processAddContributor({
         originalSha: optionsConfig.getOriginalSha(),
     }
 
-    const pullRequestURL = await repository.createPullRequestFromFiles({
-        title: `docs: add ${who} as a contributor`,
-        body: `Adds @${who} as a contributor for ${contributions.join(
-            ', ',
-        )}.\n\nThis was requested by ${commentReply.replyingToWho()} [in this comment](${commentReply.replyingToWhere()})`,
-        filesByPath: filesByPathToUpdate,
-        branchName: `all-contributors/add-${who}`,
-    })
+    const safeWho = getSafeRef(who)
+    if (contributions.length) {
+        const pullRequestURL = await repository.createPullRequestFromFiles({
+            title: `docs: add ${who} as a contributor`,
+            body: `Adds @${who} as a contributor for ${contributions.join(
+                ', ',
+            )}.\n\nThis was requested by ${commentReply.replyingToWho()} [in this comment](${commentReply.replyingToWhere()})`,
+            filesByPath: filesByPathToUpdate,
+            branchName: `all-contributors/add-${safeWho}`,
+            defaultBranch,
+        })
 
-    commentReply.reply(
-        `I've put up [a pull request](${pullRequestURL}) to add @${who}! :tada:`,
-    )
+        commentReply.reply(
+            `I've put up [a pull request](${pullRequestURL}) to add @${who}! :tada:`,
+        )
+    } else {
+        commentReply.reply(
+            `I could not find any contributions associated to @${who}! :sod:`,
+        )
+    }
 }
 
 async function probotProcessIssueComment({ context, commentReply }) {

--- a/src/tasks/processIssueComment/probot-processIssueComment.js
+++ b/src/tasks/processIssueComment/probot-processIssueComment.js
@@ -49,20 +49,24 @@ async function processAddContributor({
         originalSha: optionsConfig.getOriginalSha(),
     }
 
-    const safeWho = getSafeRef(who)
-    const pullRequestURL = await repository.createPullRequestFromFiles({
-        title: `docs: add ${who} as a contributor`,
-        body: `Adds @${who} as a contributor for ${contributions.join(
-            ', ',
-        )}.\n\nThis was requested by ${commentReply.replyingToWho()} [in this comment](${commentReply.replyingToWhere()})`,
-        filesByPath: filesByPathToUpdate,
-        branchName: `all-contributors/add-${safeWho}`,
-        defaultBranch,
-    })
+    if (contributions.length) {
+        const pullRequestURL = await repository.createPullRequestFromFiles({
+            title: `docs: add ${who} as a contributor`,
+            body: `Adds @${who} as a contributor for ${contributions.join(
+                ', ',
+            )}.\n\nThis was requested by ${commentReply.replyingToWho()} [in this comment](${commentReply.replyingToWhere()})`,
+            filesByPath: filesByPathToUpdate,
+            branchName: `all-contributors/add-${who}`,
+        })
 
-    commentReply.reply(
-        `I've put up [a pull request](${pullRequestURL}) to add @${who}! :tada:`,
-    )
+        commentReply.reply(
+            `I've put up [a pull request](${pullRequestURL}) to add @${who}! :tada:`,
+        )
+    } else {
+        commentReply.reply(
+            `I could not find any contributions associated to @${who}! :sod:`,
+        )
+    }
 }
 
 async function probotProcessIssueComment({ context, commentReply }) {

--- a/src/tasks/processIssueComment/probot-processIssueComment.js
+++ b/src/tasks/processIssueComment/probot-processIssueComment.js
@@ -69,9 +69,14 @@ async function processAddContributor({
             defaultBranch,
         })
 
-    commentReply.reply(
-        `I've put up [a pull request](${pullRequestURL}) to add @${who}! :tada:`,
-    )
+        commentReply.reply(
+            `I've put up [a pull request](${pullRequestURL}) to add @${who}! :tada:`,
+        )
+    } else {
+        commentReply.reply(
+            `I could not find any contributions associated to @${who}! :sod:`,
+        )
+    }
 }
 
 async function probotProcessIssueComment({ context, commentReply }) {

--- a/src/tasks/processIssueComment/probot-processIssueComment.js
+++ b/src/tasks/processIssueComment/probot-processIssueComment.js
@@ -69,14 +69,9 @@ async function processAddContributor({
             defaultBranch,
         })
 
-        commentReply.reply(
-            `I've put up [a pull request](${pullRequestURL}) to add @${who}! :tada:`,
-        )
-    } else {
-        commentReply.reply(
-            `I could not find any contributions associated to @${who}! :sod:`,
-        )
-    }
+    commentReply.reply(
+        `I've put up [a pull request](${pullRequestURL}) to add @${who}! :tada:`,
+    )
 }
 
 async function probotProcessIssueComment({ context, commentReply }) {

--- a/test/ContentFiles/__snapshots__/index.test.js.snap
+++ b/test/ContentFiles/__snapshots__/index.test.js.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ContentFiles Add's new contributor 1`] = `
+"# TestContentFIles
+
+[![All Contributors](https://img.shields.io/badge/all_contributors-2-orange.svg?style=flat-square)](#contributors)
+
+A test for content files generation
+
+### Content
+1. Stuff here
+2. Yeah boy
+
+
+## Contributors
+
+Thanks goes to these wonderful people ([emoji key](https://github.com/all-contributors/all-contributors#emoji-key)):
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore -->
+| [<img src=\\"https://avatars2.githubusercontent.com/u/3534236?v=4\\" width=\\"100px;\\" alt=\\"Jake Bolam\\"/><br /><sub><b>Jake Bolam</b></sub>](https://jakebolam.com)<br />[💻](#code-jakebolam \\"Code\\") [🤔](#ideas-jakebolam \\"Ideas, Planning, & Feedback\\") [🚇](#infra-jakebolam \\"Infrastructure (Hosting, Build-Tools, etc)\\") [⚠️](#test-jakebolam \\"Tests\\") | [<img src=\\"https://avatars2.githubusercontent.com/u/7265547?v=4\\" width=\\"100px;\\" alt=\\"tbenning\\"/><br /><sub><b>tbenning</b></sub>](https://github.com/tbenning)<br />[🎨](#design-tbenning \\"Design\\") |
+| :---: | :---: |
+<!-- ALL-CONTRIBUTORS-LIST:END -->
+
+This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome
+
+## LICENSE
+
+[MIT](LICENSE)
+"
+`;

--- a/test/__snapshots__/index-e2e.test.js.snap
+++ b/test/__snapshots__/index-e2e.test.js.snap
@@ -1,0 +1,80 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`All Contributors app - End to end Fail path, Unknown error (e.g. Network is dead, service down etc, our code is bad) crashes and sends error message 1`] = `
+Object {
+  "body": "@jakebolam 
+
+We had trouble processing your request. Please try again later.",
+}
+`;
+
+exports[`All Contributors app - End to end Fail path, no allcontributors file (repo needs setup) 1`] = `
+Object {
+  "body": "@jakebolam 
+
+This project is not yet setup for [all-contributors](https://github.com/all-contributors/all-contributors).
+
+    You will need to first setup [all-contributors-bot](https://github.com/all-contributors/all-contributors-bot) using the [all-contributors-cli](https://github.com/all-contributors/all-contributors-cli) tool.",
+}
+`;
+
+exports[`All Contributors app - End to end Fail path, no readme file (configuration error) 1`] = `
+Object {
+  "body": "@jakebolam 
+
+File README.md was not found in the repository (undefined).",
+}
+`;
+
+exports[`All Contributors app - End to end Fail path, no such user 1`] = `
+Object {
+  "body": "@jakebolam 
+
+Could not find the user jakebolam on github.",
+}
+`;
+
+exports[`All Contributors app - End to end Happy path, add correct new contributor 1`] = `
+Object {
+  "ref": "refs/heads/all-contributors/add-jakebolam",
+  "sha": "aa218f56b14c9653891f9e74264a383fa43fefbd",
+}
+`;
+
+exports[`All Contributors app - End to end Happy path, add correct new contributor 2`] = `
+Object {
+  "branch": "all-contributors/add-jakebolam",
+  "content": "IyBBbGxDb250cmlidXRvcnNCb3QKQSBib3QgZm9yIGF1dG9tYXRpY2FsbHkgYWRkaW5nIGFsbC1jb250cmlidXRvcnMuIPCfpJYKClshW0J1aWxkXShodHRwczovL2ltZy5zaGllbGRzLmlvL2NpcmNsZWNpL3Byb2plY3QvZ2l0aHViL2FsbC1jb250cmlidXRvcnMvYWxsLWNvbnRyaWJ1dG9ycy1ib3QvbWFzdGVyLnN2ZyldKGh0dHBzOi8vY2lyY2xlY2kuY29tL2doL2FsbC1jb250cmlidXRvcnMvYWxsLWNvbnRyaWJ1dG9ycy1ib3QpClshW0NvdmVyYWdlXShodHRwczovL2ltZy5zaGllbGRzLmlvL2NvZGVjb3YvYy9naXRodWIvYWxsLWNvbnRyaWJ1dG9ycy9hbGwtY29udHJpYnV0b3JzLWJvdC5zdmcpXShodHRwczovL2NvZGVjb3YuaW8vZ2l0aHViL2FsbC1jb250cmlidXRvcnMvYWxsLWNvbnRyaWJ1dG9ycy1ib3QpClshW0FsbCBDb250cmlidXRvcnNdKGh0dHBzOi8vaW1nLnNoaWVsZHMuaW8vYmFkZ2UvYWxsX2NvbnRyaWJ1dG9ycy0xLW9yYW5nZS5zdmc/c3R5bGU9ZmxhdC1zcXVhcmUpXSgjY29udHJpYnV0b3JzKQpbIVtDaGF0IG9uIFNsYWNrXShodHRwczovL2ltZy5zaGllbGRzLmlvL2JhZGdlL3NsYWNrLWpvaW4tZmY2OWI0LnN2ZyldKGh0dHBzOi8vam9pbi5zbGFjay5jb20vdC9hbGwtY29udHJpYnV0b3JzL3NoYXJlZF9pbnZpdGUvZW5RdE5URTNPRE15TVRBNE5UazBMVFV3WkRNeFpHWmtNbVZpTXpZell6azJZVE0yTmpSa1pHTTVZemMwWlRjNU5tWXpOV1kzWTJRMFpUWTNabUZoWkRneVkyRTNabUl6TldRd01UVXhabUUpCgoKIyMgSW5zdGFsbGF0aW9uCjEuIEluc3RhbGwgQXBwCjIuIFBsZWFzZSBzZXR1cCB5b3VyIGBSRUFETUUubWRgIGFuZCBgLmFsbC1jb250cmlidXRvcnNyY2AgdXNpbmcgdGhlIFthbGwtY29udHJpYnV0b3JzLWNsaSB0b29sXShodHRwczovL2dpdGh1Yi5jb20vYWxsLWNvbnRyaWJ1dG9ycy9hbGwtY29udHJpYnV0b3JzLWNsaSkKPiBJbiB0aGUgZnV0dXJlIHdlIHdhbnQgdG8gcmVtb3ZlIHRoZSBuZWVkIGZvciB0aGUgQ0xJIHRvb2wsIGlmIHlvdSB3YW50IHRvIGhlbHAgb3V0IFtzZWUgdGhlIGlzc3VlXShodHRwczovL2dpdGh1Yi5jb20vYWxsLWNvbnRyaWJ1dG9ycy9hbGwtY29udHJpYnV0b3JzLWJvdC9pc3N1ZXMvMykKCgojIyBVc2FnZQoKIyMjIEFkZGluZyBjb250cmlidXRpb25zCjEuIENvbW1lbnQgb24gSXNzdWUvUFIgZXRjIHdpdGggdGV4dDogYEBBbGxDb250cmlidXRvckJvdCBwbGVhc2UgYWRkIGpha2Vib2xhbSBmb3IgaW5mcmFzdHJ1Y3R1cmUsIHRlc3RpbmcgYW5kIGNvZGVgIChDYW4gYWxzbyB1c2UgdGhlIHNob3J0IHRlcm1zLCBmdWxsIGtleSBjb21pbmcgc29vbikKMi4gQm90IHdpbGwgbG9vayBmb3IgYC5hbGwtY29udHJpYnV0b3JzcmNgIGlmIG5vdCBmb3VuZCwgY29tbWVudHMgb24gcHIgdG8gcnVuIHNldHVwCjMuIElmIHVzZXIgZXhpc3RzLCBhZGQgbmV3IGNvbnRyaWJ1dGlvbiwgaWYgbm90IGFkZCB1c2VyIGFuZCBhZGQgY29udHJpYnV0aW9uCgoKIyMgQ29udHJpYnV0aW5nCklmIHlvdSBoYXZlIHN1Z2dlc3Rpb25zIGZvciBob3cgdGhlIEFsbENvbnRyaWJ1dG9yc0JvdCBjb3VsZCBiZSBpbXByb3ZlZCwgb3Igd2FudCB0byByZXBvcnQgYSBidWcsIFtvcGVuIGFuIGlzc3VlXShodHRwczovL2dpdGh1Yi5jb20vYWxsLWNvbnRyaWJ1dG9ycy9hbGwtY29udHJpYnV0b3JzLWJvdC9pc3N1ZXMpIQoKRm9yIG1vcmUsIGNoZWNrIG91dCB0aGUgW0NvbnRyaWJ1dGluZyBHdWlkZV0oQ09OVFJJQlVUSU5HLm1kKS4KCiMjIENvbnRyaWJ1dG9ycwoKVGhhbmtzIGdvZXMgdG8gdGhlc2Ugd29uZGVyZnVsIHBlb3BsZSAoW2Vtb2ppIGtleV0oaHR0cHM6Ly9naXRodWIuY29tL2FsbC1jb250cmlidXRvcnMvYWxsLWNvbnRyaWJ1dG9ycyNlbW9qaS1rZXkpKToKCjwhLS0gQUxMLUNPTlRSSUJVVE9SUy1MSVNUOlNUQVJUIC0gRG8gbm90IHJlbW92ZSBvciBtb2RpZnkgdGhpcyBzZWN0aW9uIC0tPgo8IS0tIHByZXR0aWVyLWlnbm9yZSAtLT4KfCBbPGltZyBzcmM9Imh0dHBzOi8vYXZhdGFyczIuZ2l0aHVidXNlcmNvbnRlbnQuY29tL3UvMzUzNDIzNj92PTQiIHdpZHRoPSIxMDBweDsiIGFsdD0iSmFrZSBCb2xhbSIvPjxiciAvPjxzdWI+PGI+SmFrZSBCb2xhbTwvYj48L3N1Yj5dKGh0dHBzOi8vamFrZWJvbGFtLmNvbSk8YnIgLz5b8J+Su10oaHR0cHM6Ly9naXRodWIuY29tL2FsbC1jb250cmlidHVvcnMvYm90L2NvbW1pdHM/YXV0aG9yPWpha2Vib2xhbSAiQ29kZSIpIFvwn5qHXSgjaW5mcmEtamFrZWJvbGFtICJJbmZyYXN0cnVjdHVyZSAoSG9zdGluZywgQnVpbGQtVG9vbHMsIGV0YykiKSB8CnwgOi0tLTogfAo8IS0tIEFMTC1DT05UUklCVVRPUlMtTElTVDpFTkQgLS0+CgpUaGlzIHByb2plY3QgZm9sbG93cyB0aGUgW2FsbC1jb250cmlidXRvcnNdKGh0dHBzOi8vZ2l0aHViLmNvbS9hbGwtY29udHJpYnV0b3JzL2FsbC1jb250cmlidXRvcnMpIHNwZWNpZmljYXRpb24uIENvbnRyaWJ1dGlvbnMgb2YgYW55IGtpbmQgd2VsY29tZQoKIyMgTElDRU5TRQoKW01JVF0oTElDRU5TRSkK",
+  "message": "docs: update README.md",
+  "sha": "bfce087f5fbed22257de1ee5056b20de63da0a13",
+}
+`;
+
+exports[`All Contributors app - End to end Happy path, add correct new contributor 3`] = `
+Object {
+  "branch": "all-contributors/add-jakebolam",
+  "content": "ewogICJwcm9qZWN0TmFtZSI6ICJib3QiLAogICJwcm9qZWN0T3duZXIiOiAiYWxsLWNvbnRyaWJ0dW9ycyIsCiAgInJlcG9UeXBlIjogImdpdGh1YiIsCiAgInJlcG9Ib3N0IjogImh0dHBzOi8vZ2l0aHViLmNvbSIsCiAgImZpbGVzIjogWwogICAgIlJFQURNRS5tZCIKICBdLAogICJpbWFnZVNpemUiOiAxMDAsCiAgImNvbW1pdCI6IGZhbHNlLAogICJjb250cmlidXRvcnMiOiBbCiAgICB7CiAgICAgICJsb2dpbiI6ICJqYWtlYm9sYW0iLAogICAgICAibmFtZSI6ICJKYWtlIEJvbGFtIiwKICAgICAgImF2YXRhcl91cmwiOiAiaHR0cHM6Ly9hdmF0YXJzMi5naXRodWJ1c2VyY29udGVudC5jb20vdS8zNTM0MjM2P3Y9NCIsCiAgICAgICJwcm9maWxlIjogImh0dHBzOi8vamFrZWJvbGFtLmNvbSIsCiAgICAgICJjb250cmlidXRpb25zIjogWwogICAgICAgICJjb2RlIiwKICAgICAgICAiaW5mcmEiCiAgICAgIF0KICAgIH0KICBdLAogICJjb250cmlidXRvcnNQZXJMaW5lIjogNwp9Cg==",
+  "message": "docs: update .all-contributorsrc",
+  "sha": "dff34f715bca51114c0336a49381456a926806d5",
+}
+`;
+
+exports[`All Contributors app - End to end Happy path, add correct new contributor 4`] = `
+Object {
+  "base": "master",
+  "body": "Adds @jakebolam as a contributor for code, doc, infra.
+
+This was requested by jakebolam [in this comment](https://github.com/all-contributors/all-contributors-bot/pull/1#issuecomment-453012966)",
+  "head": "all-contributors/add-jakebolam",
+  "maintainer_can_modify": true,
+  "title": "docs: add jakebolam as a contributor",
+}
+`;
+
+exports[`All Contributors app - End to end Happy path, add correct new contributor 5`] = `
+Object {
+  "body": "@jakebolam 
+
+I've put up [a pull request](https://github.com/all-contributors/all-contributors-bot/pull/1347) to add @jakebolam! :tada:",
+}
+`;

--- a/test/processIssueComment.test.js
+++ b/test/processIssueComment.test.js
@@ -1,5 +1,5 @@
 const processIssueComment = require('../src/processIssueComment')
-const { GIHUB_BOT_NAME } = require('../src/utils/settings')
+// const { GIHUB_BOT_NAME } = require('../src/utils/settings')
 
 describe('Process Issue Comment', () => {
     test('If bot, exit, do not attempt to reply', async () => {

--- a/test/processIssueComment.test.js
+++ b/test/processIssueComment.test.js
@@ -1,0 +1,66 @@
+const processIssueComment = require('../src/processIssueComment')
+const { GIHUB_BOT_NAME } = require('../src/utils/settings')
+
+describe('Process Issue Comment', () => {
+    test('If bot, exit, do not attempt to reply', async () => {
+        const mockContext = {
+            isBot: true,
+            log: {
+                debug: jest.fn(),
+            },
+            github: jest.fn(),
+        }
+        await processIssueComment({ context: mockContext })
+        expect(mockContext.log.debug).toHaveBeenCalledWith(
+            'From a bot, exiting',
+        )
+        expect(mockContext.github).not.toHaveBeenCalled()
+    })
+
+    test('If not for us, exit, do not attempt to reply', async () => {
+        const mockContext = {
+            isBot: false,
+            log: {
+                debug: jest.fn(),
+            },
+            github: jest.fn(),
+            payload: {
+                comment: {
+                    body: `Some body's message`,
+                },
+            },
+        }
+        await processIssueComment({ context: mockContext })
+        expect(mockContext.log.debug).toHaveBeenCalledWith(
+            'Message not for us, exiting',
+        )
+        expect(mockContext.github).not.toHaveBeenCalled()
+    })
+
+    // test('If there is nil contributions, inform about it', async () => {
+    //     const mockContext = {
+    //         isBot: false,
+    //         log: {
+    //             debug: jest.fn(),
+    //         },
+    //         github: jest.fn(),
+    //         payload: {
+    //             comment: {
+    //                 body: `@${GIHUB_BOT_NAME} please add jakebolam for `,
+    //                 user: {
+    //                     login: '@Berkmann18',
+    //                     html_url: '',
+    //                     issue: jest.fn
+    //                 }
+    //             },
+    //         }
+    //     }
+    //     await processIssueComment({ context: mockContext })
+    //     expect(mockContext.log.debug).toHaveBeenCalledWith(
+    //         'No contributions',
+    //     )
+    //    expect(mockContext.github).not.toHaveBeenCalled()
+    // })
+})
+
+// 'Message not for us, exiting'

--- a/test/processIssueComment.test.js
+++ b/test/processIssueComment.test.js
@@ -1,4 +1,4 @@
-const processIssueComment = require('../src/processIssueComment')
+const processIssueComment = require('../src/probot-processIssueComment')
 // const { GIHUB_BOT_NAME } = require('../src/utils/settings')
 
 describe('Process Issue Comment', () => {

--- a/test/tasks/processIssueComment/__snapshots__/probot-app-e2e.test.js.snap
+++ b/test/tasks/processIssueComment/__snapshots__/probot-app-e2e.test.js.snap
@@ -8,6 +8,14 @@ We had trouble processing your request. Please try again later.",
 }
 `;
 
+exports[`All Contributors app - End to end Fail path, Unknown error (e.g. Network is dead, service down etc, our code is bad) crashes and sends error message 2`] = `
+Object {
+  "body": "@jakebolam 
+
+We had trouble processing your request. Please try again later.",
+}
+`;
+
 exports[`All Contributors app - End to end Fail path, no readme file (configuration error) 1`] = `
 Object {
   "body": "@jakebolam 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1766,7 +1766,7 @@ debug@^4.0.0, debug@^4.0.1, debug@^4.1.0:
   dependencies:
     ms "^2.1.1"
 
-debuglog@*, debuglog@^1.0.1:
+debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
 
@@ -3273,7 +3273,7 @@ import-local@^1.0.0:
     pkg-dir "^2.0.0"
     resolve-cwd "^2.0.0"
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
 
@@ -4469,10 +4469,6 @@ lockfile@^1.0.4:
   dependencies:
     signal-exit "^3.0.2"
 
-lodash._baseindexof@*:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
-
 lodash._baseuniq@~4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz#0ebb44e456814af7905c6212fa2c9b2d51b841e8"
@@ -4480,27 +4476,9 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
-lodash._bindcallback@*:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
-
-lodash._cacheindexof@*:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
-
-lodash._createcache@*:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
-  dependencies:
-    lodash._getnative "^3.0.0"
-
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
-
-lodash._getnative@*, lodash._getnative@^3.0.0:
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
 
 lodash._root@~3.0.0:
   version "3.0.1"
@@ -4582,10 +4560,6 @@ lodash.padstart@^4.1.0:
 lodash.pick@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
-
-lodash.restparam@*:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
 
 lodash.set@^4.3.2:
   version "4.3.2"
@@ -6333,7 +6307,7 @@ readable-stream@~1.1.10:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-readdir-scoped-modules@*, readdir-scoped-modules@^1.0.0:
+readdir-scoped-modules@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz#9fafa37d286be5d92cbaebdee030dc9b5f406747"
   dependencies:


### PR DESCRIPTION
This should resolve #31.
## How?
By checking, right before submitting a PR and commenting, if the `contributions` array is empty or not.
If it is, it will comment accordingly otherwise proceed as usual.