### PR TITLE
fix: changed `error.code` to `error.status` (#54)

### DIFF
--- a/src/Repository/index.js
+++ b/src/Repository/index.js
@@ -21,7 +21,7 @@ class Repository {
                 path: filePath,
             })
         } catch (error) {
-            if (error.code === 404) {
+            if (error.status === 404) {
                 throw new ResourceNotFoundError(filePath, this.full_name)
             } else {
                 throw error

--- a/src/utils/getUserDetails.js
+++ b/src/utils/getUserDetails.js
@@ -15,7 +15,7 @@ async function getUserDetials({ github, username }) {
     try {
         result = await github.users.getByUsername({ username })
     } catch (error) {
-        if (error.code === 404) {
+        if (error.status === 404) {
             throw new UserNotFoundError(username)
         } else {
             throw error


### PR DESCRIPTION
Due to deprecation warnings, I changed the `code` attribute to `status` to fix #54.

_Note_: the `master` branch (up to e241b5d81352a1645cf9f2b8ec1ff90989b9a455) seems to fail when locally running `yarn test` namely with this error: `TypeError: initBadge is not a function`.