### PR TITLE
Remove name field from app.yml

### DIFF
--- a/app.yml
+++ b/app.yml
@@ -125,9 +125,6 @@ default_permissions:
   # organization_administration: read
 
 
-# The name of the GitHub App. Defaults to the name specified in package.json
-name: AllContributors Test Bot
-
 # The homepage of your GitHub App.
 url: https://all-contributors.js.org
 


### PR DESCRIPTION
Hiya! Super cool app and even cooler that you built it with Probot! I was just peaking at the code and noticed this very minor nit. (Feel free to ignore!)

Right now GitHub App names are namespaced in a way in which they must be entirely unique from all other app, user, or org names. Therefore, filling in this name value results in an error. This will always happen due to the name defaulting from the package.json, but it just means this is irrelevant 🤷‍♀️ 