### PR TITLE
fix: sentry type error AllContributorBotError is not a constructor

### DIFF
--- a/src/tasks/processIssueComment/ContentFiles/index.js
+++ b/src/tasks/processIssueComment/ContentFiles/index.js
@@ -1,7 +1,7 @@
 const { generate: generateContentFile } = require('all-contributors-cli')
 const { initBadge, initContributorsList } = require('all-contributors-cli')
 
-const AllContributorBotError = require('../utils/errors')
+const { AllContributorBotError } = require('../utils/errors')
 
 function modifyFiles({ contentFilesByPath, fileContentModifierFunction }) {
     const newFilesByPath = {}


### PR DESCRIPTION
Related sentry error: https://sentry.io/organizations/all-contributors/issues/914046607/?project=1366866&referrer=slack&statsPeriod=14d