### PR TITLE
infra: keep stats lambda warm when probot sync happens

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -62,6 +62,7 @@ functions:
           path: /probot/stats
           method: get
           cors: true
+      - schedule: cron(0/5 22-23 * * * *) # Ping stats handler every 5 minutes to stay warm, every day, between 22-23 PM
     memorySize: 512
     timeout: 30
   healthCheck:


### PR DESCRIPTION
This is another mitigation against https://github.com/all-contributors/all-contributors-bot/issues/167

Keeping the lambda warm, along with memory cache (https://github.com/all-contributors/all-contributors-bot/pull/133) during the time we expect probot to sync should help mitigate against this.

See also https://github.com/probot/probot/issues/380