### PR TITLE
chore: fix typo in parse-comment

### DIFF
--- a/src/tasks/processIssueComment/utils/parse-comment/index.js
+++ b/src/tasks/processIssueComment/utils/parse-comment/index.js
@@ -31,7 +31,7 @@ const validContributionTypes = [
     'video',
 ]
 
-// Types that are valid multi words, that we need to re map back to there camelCase parts
+// Types that are valid multi words, that we need to re map back to their camelCase parts
 const validMultiContributionTypesMapping = {
     eventorganizing: 'eventOrganizing',
     fundingfinding: 'fundingFinding',


### PR DESCRIPTION
I found this small typo when reading through the source code, so I thought I'd fix it 👍 