### PR TITLE
fix: only respond to users if they refer to the bot with a space at t…

### DIFF
--- a/src/utils/isMessageForBot.js
+++ b/src/utils/isMessageForBot.js
@@ -1,9 +1,9 @@
 function isMessageForBot(message) {
     const lowerCaseMessage = message.toLowerCase()
     const isMessageForBot =
-        lowerCaseMessage.includes(`@all-contributors`) ||
-        lowerCaseMessage.includes(`@allcontributors`) ||
-        lowerCaseMessage.includes(`@allcontributors[bot]`)
+        /@all-contributors\s/.test(lowerCaseMessage) ||
+        /@allcontributors\s/.test(lowerCaseMessage) ||
+        /@allcontributors\[bot\]\s/.test(lowerCaseMessage)
     return isMessageForBot
 }
 

--- a/test/utils/isMessageForBot.test.js
+++ b/test/utils/isMessageForBot.test.js
@@ -10,6 +10,12 @@ describe('isMessageForBot', () => {
 
         expect(
             isMessageForBot(
+                `@all-contributors\nplease add jakebolam for doc, infra and code`,
+            ),
+        ).toBe(true)
+
+        expect(
+            isMessageForBot(
                 `@allcontributors[bot] please add jakebolam for doc, infra and code`,
             ),
         ).toBe(true)
@@ -33,6 +39,13 @@ describe('isMessageForBot', () => {
         expect(
             isMessageForBot(
                 `all-contributors please add jakebolam for doc, infra and code`,
+            ),
+        ).toBe(false)
+
+        // No space
+        expect(
+            isMessageForBot(
+                `@all-contributors/please add jakebolam for doc, infra and code`,
             ),
         ).toBe(false)
 


### PR DESCRIPTION
Only respond to users if they call the bot with a space at the end.