### PR TITLE
docs: fix typos

### DIFF
--- a/contributing/bot-architecture.md
+++ b/contributing/bot-architecture.md
@@ -5,7 +5,7 @@ Structure:
 - `ContentFiles`, or readmes files that will be re-generated and updated with the table
 - `OptionsConfig`, the configuration for the bot, and the list of contributions
 - `Repository`, used by ContentFiles and OptionsConfig for getting files, updating files, creating branches and pull requests
-- `utils/parse-comment` used for determing the intention of the users comment
+- `utils/parse-comment` used for determining the intention of the users comment
 
 Uses [Probot](https://github.com/probot/probot) for incoming events, and communicating/authenticating with github. [Probot docs](https://probot.github.io/docs/), [GitHub oktokit/restjs API docs](https://octokit.github.io/rest.js/)
 

--- a/src/tasks/processIssueComment/utils/parse-comment/index.js
+++ b/src/tasks/processIssueComment/utils/parse-comment/index.js
@@ -144,7 +144,7 @@ function parseAddComment(message, action) {
 
     // Contributions
     const doc = nlp(message).toLowerCase()
-    // This is to support multi word 'matches' (altho the compromise docs say it supports this *confused*)
+    // This is to support multi word 'matches' (although the compromise docs say it supports this *confused*)
     Object.entries(contributionTypeMultiWordMapping).forEach(
         ([multiWordType, singleWordType]) => {
             doc.replace(multiWordType, singleWordType)


### PR DESCRIPTION
Hi,

This tiny PR will fix : 

- 1 typo in `contributing/bot-architecture.md`
- 1 typo in `src/tasks/processIssueComment/utils/parse-comment/index.js`



Best! :robot: