### PR TITLE
ci: run daily stats action

### DIFF
--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -1,0 +1,18 @@
+on:
+    schedule:
+        # https://crontab.guru/once-a-day
+        - cron: 0 0 * * *
+    workflow_dispatch: {}
+
+name: Stats
+jobs:
+    stats:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: gr2m/app-stats-action@v1.x
+              id: stats
+              with:
+                  id: ${{ secrets.ALL_CONTRIBUTORS_APP_ID }}
+                  private_key: ${{ secrets.ALL_CONTRIBUTORS_APP_PRIVATE_KEY }}
+            - run: "echo installations: '${{ steps.stats.outputs.installations }}'"
+            - run: "echo most popular repositories: '${{ steps.stats.outputs.popular_repositories }}'"


### PR DESCRIPTION
See https://github.com/wip/app/actions?query=workflow%3AStats for comparison.

FYI the app has currently 3334 installations.