### PR TITLE
chore: update CI and docs for Node.js 22 and `main` branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,14 +2,14 @@ name: Release
 "on":
   push:
     branches:
-      - master
+      - main
 jobs:
   release:
     name: release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           cache: npm
           node-version: lts/*

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Test
 "on":
   push:
     branches:
-      - master
+      - main
   pull_request:
     types:
       - opened
@@ -11,11 +11,11 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           cache: npm
-          node-version: 16
+          node-version: 22
       - run: npm ci
       - run: npm test
       - name: Run code coverage

--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -1,1 +1,1 @@
-See the [code of conduct for all-contributors](https://github.com/all-contributors/all-contributors/blob/master/other/CODE_OF_CONDUCT.md) organization
+See the [code of conduct for all-contributors](https://github.com/all-contributors/all-contributors/blob/main/other/CODE_OF_CONDUCT.md) organization

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 </table>
 
 [![Build](https://github.com/all-contributors/app/actions/workflows/test.yml/badge.svg)](https://github.com/all-contributors/app/actions/workflows/test.yml)
-[![Coverage](https://codecov.io/gh/all-contributors/app/branch/master/graph/badge.svg?token=PduWRhZBYo)](https://codecov.io/gh/all-contributors/app)
+[![Coverage](https://codecov.io/gh/all-contributors/app/branch/main/graph/badge.svg?token=PduWRhZBYo)](https://codecov.io/gh/all-contributors/app)
 [![GitHub release](https://img.shields.io/github/release/all-contributors/all-contributors-bot.svg?style=flat-square)](https://github.com/all-contributors/all-contributors-bot/releases)
 [![All Contributors](https://img.shields.io/badge/all_contributors-13-orange.svg?style=flat-square)](#contributors)
 [![Star on Github](https://img.shields.io/github/stars/all-contributors/all-contributors-bot.svg?style=flat-square)](https://github.com/all-contributors/all-contributors-bot/stargazers)
@@ -38,7 +38,7 @@ Implementing the [All Contributors spec](https://github.com/all-contributors/all
 Enter the `@all-contributors bot`! The bot will automatically pull a user's profile, grab the contribution type emoji, update the project README and then open a Pull Request against the project :sparkles:
 
 <a href="https://allcontributors.org/docs/en/bot/usage">
-    <img alt="Example usage screenshot" src="https://raw.githubusercontent.com/all-contributors/all-contributors/master/docs/assets/bot-usage.png" width="500px">
+    <img alt="Example usage screenshot" src="https://raw.githubusercontent.com/all-contributors/all-contributors/main/docs/assets/bot-usage.png" width="500px">
 </a>
 
 ## Using the @all-contributors bot 🤖

--- a/contributing/run-bot-locally.md
+++ b/contributing/run-bot-locally.md
@@ -19,8 +19,8 @@ Required fields are:
 Important fields are:
 
 - `webhook secret`, set this to `development`
-- `Permissions` which should be set [as defined in the app.yml](https://github.com/all-contributors/all-contributors-bot/blob/master/app.yml#L54), e.g. set read & write for `Repository contents`, `Issues` and `Pull Requests`, and read for `Repository Metadata`
-- `Subscribe to Events` which should be set [as defined in the app.yml](https://github.com/all-contributors/all-contributors-bot/blob/master/app.yml#L15), e.g. check the checkbox for `Issue comment`
+- `Permissions` which should be set [as defined in the app.yml](https://github.com/all-contributors/all-contributors-bot/blob/main/app.yml#L54), e.g. set read & write for `Repository contents`, `Issues` and `Pull Requests`, and read for `Repository Metadata`
+- `Subscribe to Events` which should be set [as defined in the app.yml](https://github.com/all-contributors/all-contributors-bot/blob/main/app.yml#L15), e.g. check the checkbox for `Issue comment`
 - Ensure `Where can this GitHub App be installed?` is set to `only this account`
   ![where can this app be installed](where-can-this-app-be-installed.png)
 

--- a/contributing/working-with-forks.md
+++ b/contributing/working-with-forks.md
@@ -4,7 +4,7 @@
 
 1. `git remote add parent git@github.com:all-contributors/all-contributors-bot.git`
 2. `git fetch parent`
-3. `git checkout master` or `git checkout empty-contribs` (this branch on your fork)
-4. `git merge parent/master`
+3. `git checkout main` or `git checkout empty-contribs` (this branch on your fork)
+4. `git merge parent/main`
 
 See https://help.github.com/articles/syncing-a-fork/

--- a/privacy-policy.md
+++ b/privacy-policy.md
@@ -20,7 +20,7 @@ When installing the the app you grant it access to the following three scopes
 
 3. **Read & write access to [contents](https://developer.github.com/v3/apps/permissions/#permission-on-contents)**
 
-   The app app uses `.all-contributorsrc` to manage configuration for the app per repo, and list of contributors. It also will read & write to the `README.md` file, or any other [files configurged](https://github.com/all-contributors/all-contributors-cli#configuration) in your `.all-contributorsrc` file under the `files` key. No files will be directly updated on the default/`master` branches, all files will be updated in branches and pull-requests created.
+   The app app uses `.all-contributorsrc` to manage configuration for the app per repo, and list of contributors. It also will read & write to the `README.md` file, or any other [files configurged](https://github.com/all-contributors/all-contributors-cli#configuration) in your `.all-contributorsrc` file under the `files` key. No files will be directly updated on the default/`main` branches, all files will be updated in branches and pull-requests created.
 
 The app receives [IssueComment](https://developer.github.com/v3/activity/events/types/#issuecommentevent) events from GitHub, but any data not required for the functionality of the app is discarded.
 


### PR DESCRIPTION
This should get CI running, accounting for two changes:

* The default branch being renamed from `master` to `main`
* Node.js 16 no longer being within LTS - 22 will be for a while now

Amusingly, this PR's CI is still ❌ failing even though it does fix CI to run. That's because of #530: there are test failures.

Fixes #529.